### PR TITLE
Fix skip-duplicates

### DIFF
--- a/.github/workflows/dotnet.yaml
+++ b/.github/workflows/dotnet.yaml
@@ -149,7 +149,7 @@ jobs:
         with:
           name: nuget-package
       - name: Publish to NuGet
-        run: dotnet nuget push "ShapeSifter.*.nupkg" --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicates
+        run: dotnet nuget push "ShapeSifter.*.nupkg" --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
 
   github-tag-and-release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Wouldn't it be lovely if the .NET CLI had a `--dry-run` mode like every other tool in the world 😢 then we could have caught this *before* prod.