### PR TITLE
Bump SDK and stop testing below net8

### DIFF
--- a/.github/workflows/dotnet.yaml
+++ b/.github/workflows/dotnet.yaml
@@ -20,7 +20,6 @@ jobs:
           - macOS-latest
           - windows-latest
         dotnet:
-          - { sdk: 6.0.x, framework: net6.0 }
           - { sdk: 8.0.x, framework: net8.0 }
 
     runs-on: ${{matrix.os}}
@@ -45,10 +44,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Setup .NET SDK v6.0.x
+      - name: Setup .NET SDK v8.0.x
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 6.0.x
+          dotnet-version: 8.0.x
       - name: Prepare .NET tools
         run: dotnet tool restore
       - name: Run Fantomas
@@ -61,10 +60,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Setup .NET SDK v6.0.x
+      - name: Setup .NET SDK v8.0.x
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 6.0.x
+          dotnet-version: 8.0.x
       - name: Prepare .NET tools
         run: dotnet tool restore
       - name: Prepare analyzers
@@ -85,10 +84,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0 # so that NerdBank.GitVersioning has access to history
-      - name: Setup .NET SDK v6.0.x
+      - name: Setup .NET SDK v8.0.x
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 6.0.x
+          dotnet-version: 8.0.x
       - name: Build
         run: dotnet build ShapeSifter/ShapeSifter.fsproj --configuration Release
       - name: Pack

--- a/ShapeSifter.Test/ShapeSifter.Test.fsproj
+++ b/ShapeSifter.Test/ShapeSifter.Test.fsproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <WarningLevel>5</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsAsErrors />
@@ -21,7 +21,11 @@
     <PackageReference Include="ApiSurface" Version="4.0.40" />
     <PackageReference Include="FsUnit" Version="6.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
     <PackageReference Include="NUnit" Version="4.1.0" />
+    <!-- stop NuGet from yapping: -->
+    <PackageReference Include="System.Text.Json" Version="8.0.4" />
+    <PackageReference Include="System.Formats.Asn1" Version="8.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ShapeSifter/SurfaceBaseline.txt
+++ b/ShapeSifter/SurfaceBaseline.txt
@@ -67,6 +67,7 @@ ShapeSifter.Patterns inherit obj
 ShapeSifter.Patterns+TType`1 inherit obj, implements 'a ShapeSifter.Patterns+TType System.IEquatable, System.Collections.IStructuralEquatable, 'a ShapeSifter.Patterns+TType System.IComparable, System.IComparable, System.Collections.IStructuralComparable - union type with 1 cases
 ShapeSifter.Patterns+TType`1.get_Item [method]: unit -> unit
 ShapeSifter.Patterns+TType`1.get_Tag [method]: unit -> int
+ShapeSifter.Patterns+TType`1.Equals [method]: ('a ShapeSifter.Patterns+TType, System.Collections.IEqualityComparer) -> bool
 ShapeSifter.Patterns+TType`1.Item [property]: [read-only] unit
 ShapeSifter.Patterns+TType`1.NewTType [static method]: unit -> 'a ShapeSifter.Patterns+TType
 ShapeSifter.Patterns+TType`1.Tag [property]: [read-only] int

--- a/ShapeSifter/version.json
+++ b/ShapeSifter/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0",
+  "version": "1.1",
   "publicReleaseRefSpec": [
     "^refs/heads/main$"
   ],

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "8.0.400",
+    "rollForward": "latestMajor"
+  }
+}


### PR DESCRIPTION
The merge of https://github.com/dotnet/fsharp/pull/16857 has changed our API surfaces. Bump SDK to fix the surface.