### PR TITLE
Dependabot updates, and fix path filters

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,13 +3,13 @@
   "isRoot": true,
   "tools": {
     "fantomas": {
-      "version": "6.3.4",
+      "version": "6.3.16",
       "commands": [
         "fantomas"
       ]
     },
     "fsharp-analyzers": {
-      "version": "0.26.0",
+      "version": "0.28.0",
       "commands": [
         "fsharp-analyzers"
       ]

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -13,7 +13,7 @@
     <DebugType>embedded</DebugType>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Nerdbank.GitVersioning" Version="3.6.146" PrivateAssets="all" />
+    <PackageReference Include="Nerdbank.GitVersioning" Version="3.7.112" PrivateAssets="all" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
     <SourceLinkGitHubHost Include="github.com" ContentUrl="https://raw.githubusercontent.com" />
   </ItemGroup>

--- a/ShapeSifter/ShapeSifter.fsproj
+++ b/ShapeSifter/ShapeSifter.fsproj
@@ -45,7 +45,7 @@
 
   <ItemGroup>
     <PackageReference Update="FSharp.Core" Version="4.5.0" />
-    <PackageReference Include="HeterogeneousCollections" Version="1.0.7" />
+    <PackageReference Include="HeterogeneousCollections" Version="1.0.10" />
   </ItemGroup>
 
 </Project>

--- a/ShapeSifter/version.json
+++ b/ShapeSifter/version.json
@@ -5,7 +5,7 @@
   ],
   "pathFilters": [
     ":/",
-    ":^ShapeSifter.Test/",
+    ":^/ShapeSifter.Test/",
     ":^/.github/",
     ":^/.config/",
     ":^/hooks/",

--- a/analyzers/analyzers.fsproj
+++ b/analyzers/analyzers.fsproj
@@ -5,13 +5,13 @@
     <IsPublishable>false</IsPublishable>
     <RestorePackagesPath>../.analyzerpackages/</RestorePackagesPath> <!-- Changes the global packages folder-->
     <!-- <MSBuildProjectExtensionsPath>$(RestorePackagesPath)obj/</MSBuildProjectExtensionsPath> --> <!-- It's still PackageReference, so project intermediates are still created. -->
-    <TargetFramework>net6.0</TargetFramework> <!-- This is not super relevant, as long as your SDK version supports it. -->
+    <TargetFramework>net8.0</TargetFramework> <!-- This is not super relevant, as long as your SDK version supports it. -->
     <DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder> <!-- If a package is resolved to a fallback folder, it may not be downloaded.-->
     <AutomaticallyUseReferenceAssemblyPackages>false</AutomaticallyUseReferenceAssemblyPackages> <!-- We don't want to build this project, so we do not need the reference assemblies for the framework we chose.-->
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageDownload Include="G-Research.FSharp.Analyzers" Version="[0.10.0]" />
+    <PackageDownload Include="G-Research.FSharp.Analyzers" Version="[0.12.0]" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
To avoid a slew of releases (for the HeterogeneousCollections and NerdBank.GitVersioning upgrades and the path filters fix), I've folded all these into one. Drive-by fix of the path filters in version.json too. The upgrade of fsharp-analyzers required an upgrade of the analyzers DLL to match the increased analyser SDK version.

This supersedes #25, #26, #27, and #28.