### PR TITLE
Bump Nerdbank.GitVersioning

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -13,7 +13,7 @@
     <DebugType>embedded</DebugType>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Nerdbank.GitVersioning" Version="3.7.115" PrivateAssets="all" />
+    <PackageReference Include="Nerdbank.GitVersioning" Version="3.8.38-alpha" PrivateAssets="all" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
     <SourceLinkGitHubHost Include="github.com" ContentUrl="https://raw.githubusercontent.com" />
   </ItemGroup>

--- a/ShapeSifter.Test/Attribute.fs
+++ b/ShapeSifter.Test/Attribute.fs
@@ -1,12 +1,13 @@
 namespace ShapeSifter.Test
 
+open System.Reflection
 open ShapeSifter
 
 [<RequireQualifiedAccess>]
 module Attribute =
 
     /// The F# compiler puts in a bunch of attributes on each of these cases; we're not interested in that.
-    let filterFromField<'a> (field : TypeField<'a>) =
+    let filterFromField<'a> (field : TypeField<'a>) : CustomAttributeData list =
         field.Attributes
         |> List.filter (fun attr ->
             [
@@ -15,4 +16,14 @@ module Attribute =
                 typeof<System.Diagnostics.DebuggerDisplayAttribute>
             ]
             |> List.forall (fun t -> attr.AttributeType <> t)
+        )
+
+    /// Remove built-in runtime attributes like CompilerGeneratedAttribute.
+    let filterRuntime (attrs : CustomAttributeData list) : System.Type list =
+        attrs
+        |> List.choose (fun attr ->
+            if attr.AttributeType.Module.Name = "System.Private.CoreLib.dll" then
+                None
+            else
+                Some attr.AttributeType
         )

--- a/ShapeSifter.Test/TestUnion.fs
+++ b/ShapeSifter.Test/TestUnion.fs
@@ -2,6 +2,7 @@ namespace ShapeSifter.Test
 
 open System
 
+open System.Reflection
 open NUnit.Framework
 open FsUnitTyped
 
@@ -45,20 +46,20 @@ module TestUnion =
 
         attributes.Count |> shouldEqual 4
 
-        attributes.["Case1"] |> shouldBeEmpty
+        attributes.["Case1"] |> Attribute.filterRuntime |> shouldBeEmpty
 
         attributes.["Case2"]
+        |> Attribute.filterRuntime
         |> List.exactlyOne
-        |> fun data -> data.AttributeType
         |> shouldEqual typeof<Foo>
 
         attributes.["Case3"]
+        |> Attribute.filterRuntime
         |> List.exactlyOne
-        |> fun data -> data.AttributeType
         |> shouldEqual typeof<Bar>
 
         attributes.["Case4"]
-        |> List.map (fun data -> data.AttributeType)
+        |> Attribute.filterRuntime
         |> List.sortBy (fun ty -> ty.Name)
         |> shouldEqual [ typeof<Bar> ; typeof<Foo> ]
 
@@ -86,9 +87,9 @@ module TestUnion =
             |> Map.ofList
 
         attributes.Count |> shouldEqual 2
-        attributes.["Field1"] |> shouldBeEmpty
+        attributes.["Field1"] |> Attribute.filterRuntime |> shouldBeEmpty
 
         attributes.["Field2"]
+        |> Attribute.filterRuntime
         |> List.exactlyOne
-        |> fun data -> data.AttributeType
         |> shouldEqual typeof<Foo>

--- a/ShapeSifter.Test/TestUnion.fs
+++ b/ShapeSifter.Test/TestUnion.fs
@@ -11,7 +11,7 @@ open ShapeSifter.Patterns
 [<TestFixture>]
 module TestUnion =
 
-    [<AttributeUsage(AttributeTargets.Property, Inherited = true)>]
+    [<AttributeUsage(AttributeTargets.Method ||| AttributeTargets.Property, Inherited = true)>]
     type Foo () =
         inherit Attribute ()
 


### PR DESCRIPTION
This picks up https://github.com/dotnet/Nerdbank.GitVersioning/pull/1174 , allowing us to build without workarounds on 9.0.20x.

Also bundles a fix for https://github.com/dotnet/fsharp/issues/18298 .