### PR TITLE
Pin the toolchain

### DIFF
--- a/ShapeSifter.Test/ShapeSifter.Test.fsproj
+++ b/ShapeSifter.Test/ShapeSifter.Test.fsproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>net10.0</TargetFrameworks>
     <WarningLevel>5</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsAsErrors />
@@ -18,14 +18,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="ApiSurface" Version="4.0.40" />
-    <PackageReference Include="FsUnit" Version="6.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
-    <PackageReference Include="NUnit" Version="4.1.0" />
-    <!-- stop NuGet from yapping: -->
-    <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Formats.Asn1" Version="8.0.1" />
+    <PackageReference Include="ApiSurface" Version="5.0.8" />
+    <PackageReference Include="FsUnit" Version="7.1.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="6.3.0" />
+    <PackageReference Include="NUnit" Version="4.6.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.400",
-    "rollForward": "latestMajor"
+    "version": "10.0.300",
+    "rollForward": "latestFeature"
   }
 }


### PR DESCRIPTION
We're suffering from a derivative of https://github.com/dotnet/fsharp/issues/20253 (which is in the 10.0.400 band), which is fixed in HEAD (https://github.com/dotnet/fsharp/pull/20260) but not yet released.